### PR TITLE
chore: add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ CXXFLAGS ?= -O3 -march=native
 BUILDFLAGS = -std=c++20 -Wall -Wextra -pedantic
 LIBS = -lX11 -lXi
 
+.PHONY: all
 all: xautocfg
 
 xautocfg: xautocfg.o
@@ -15,6 +16,12 @@ xautocfg: xautocfg.o
 %.o: %.cpp
 	${CXX} ${BUILDFLAGS} ${CXXFLAGS} -c $^ -o $@
 
+.PHONY: install
+install: all
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install -d $(DESTDIR)$(PREFIX)/man1
+	install -m 0755 xautocfg $(DESTDIR)$(PREFIX)/bin
+	install -m 0644 xautocfg.1 $(DESTDIR)$(MANPREFIX)/man1/
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Adds an install target so that distributions can package the tool more easily.